### PR TITLE
Lottery contract fix for EVM Paris upgrade

### DIFF
--- a/lottery/README.md
+++ b/lottery/README.md
@@ -57,7 +57,7 @@ contract Lottery {
     //
     // VM Paris Update: Note that in September 2022, Ethereum transitioned to proof-of-stake consensus,
     // also known as The Merge. One of the changes this resulted in was the introduction of a new
-    // opcode called 'prevrandao', which replaces the 'difficulty' opcode. As such, since Solidity >= 0.8.18
+    // opcode called 'prevrandao', which replaces the 'difficulty' opcode. As such, since Solidity 0.8.18
     // block.difficulty has been deprecated and instead, block.prevrandao should be used.
     return uint256(keccak256(abi.encodePacked(block.prevrandao, block.number, players)));
   }

--- a/lottery/README.md
+++ b/lottery/README.md
@@ -54,7 +54,12 @@ contract Lottery {
   function random() private view returns (uint256) {
     // For an explanation of why `abi.encodePacked` is used here, see
     // https://github.com/owanhunte/ethereum-solidity-course-updated-code/issues/1
-    return uint256(keccak256(abi.encodePacked(block.difficulty, block.number, players)));
+    //
+    // VM Paris Update: Note that in September 2022, Ethereum transitioned to proof-of-stake consensus,
+    // also known as The Merge. One of the changes this resulted in was the introduction of a new
+    // opcode called 'prevrandao', which replaces the 'difficulty' opcode. As such, since Solidity >= 0.8.18
+    // block.difficulty has been deprecated and instead, block.prevrandao should be used.
+    return uint256(keccak256(abi.encodePacked(block.prevrandao, block.number, players)));
   }
 
   function pickWinner() public onlyOwner {

--- a/lottery/contracts/Lottery.sol
+++ b/lottery/contracts/Lottery.sol
@@ -33,7 +33,12 @@ contract Lottery {
   function random() private view returns (uint256) {
     // For an explanation of why `abi.encodePacked` is used here, see
     // https://github.com/owanhunte/ethereum-solidity-course-updated-code/issues/1
-    return uint256(keccak256(abi.encodePacked(block.difficulty, block.number, players)));
+    //
+    // VM Paris Update: Note that in September 2022, Ethereum transitioned to proof-of-stake consensus,
+    // also known as The Merge. One of the changes this resulted in was the introduction of a new
+    // opcode called 'prevrandao', which replaces the 'difficulty' opcode. As such, since Solidity >= 0.8.18
+    // block.difficulty has been deprecated and instead, block.prevrandao should be used.
+    return uint256(keccak256(abi.encodePacked(block.prevrandao, block.number, players)));
   }
 
   function pickWinner() public onlyOwner {

--- a/lottery/contracts/Lottery.sol
+++ b/lottery/contracts/Lottery.sol
@@ -36,7 +36,7 @@ contract Lottery {
     //
     // VM Paris Update: Note that in September 2022, Ethereum transitioned to proof-of-stake consensus,
     // also known as The Merge. One of the changes this resulted in was the introduction of a new
-    // opcode called 'prevrandao', which replaces the 'difficulty' opcode. As such, since Solidity >= 0.8.18
+    // opcode called 'prevrandao', which replaces the 'difficulty' opcode. As such, since Solidity 0.8.18
     // block.difficulty has been deprecated and instead, block.prevrandao should be used.
     return uint256(keccak256(abi.encodePacked(block.prevrandao, block.number, players)));
   }


### PR DESCRIPTION
In September 2022, Ethereum transitioned to proof-of-stake consensus, also known as [The Merge](https://ethereum.org/en/upgrades/merge). One of the changes this resulted in was the introduction of a new opcode called **prevrandao**, which replaces the `difficulty` opcode. As such, since Solidity 0.8.18 `block.difficulty` has been deprecated and instead, `block.prevrandao` should be used. This PR makes that change in the Lottery contract's source code.